### PR TITLE
Add unitary tests, improve date and description parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 5.5
   - 5.4
+  - 5.3
 install:
   - composer self-update
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: php
+php:
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+install:
+  - composer self-update
+  - composer install
+script:
+  - make test

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 
+Copyright (c) 2015-2016 Kafene and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+BIN = vendor/bin
+
+test:
+	@$(BIN)/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,9 @@
     "keywords": ["parse", "bookmark", "netscape"],
     "homepage": "https://github.com/kafene/BookmarkParser",
     "license": "MIT",
-    "autoload": {"files": ["parse_netscape_bookmarks.php"]}
+    "autoload": {"files": ["parse_netscape_bookmarks.php"]},
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "4.6.*"
+    }
 }

--- a/parse_netscape_bookmarks.php
+++ b/parse_netscape_bookmarks.php
@@ -7,7 +7,7 @@ function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
 
     $current_tag = $default_tag = $default_tag ?: 'imported-'.date("Ymd");
 
-    $bkmk_str = str_replace(array("\r","\n","\t"), array('','',' '), $bkmk_str);
+    $bkmk_str = str_replace(array("\r", "\t"), array('',' '), $bkmk_str);
 
     $bkmk_str = preg_replace_callback('@<dd>(.*?)(<A|<\/|<DL|<DT|<P)@mis', function($m) {
         return '<dd>'.str_replace(array("\r", "\n"), array('', '<br>'), trim($m[1])).'</';

--- a/parse_netscape_bookmarks.php
+++ b/parse_netscape_bookmarks.php
@@ -3,14 +3,14 @@
 function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
     $i = 0;
     $next = false;
-    $items = [];
+    $items = array();
 
     $current_tag = $default_tag = $default_tag ?: 'imported-'.date("Ymd");
 
-    $bkmk_str = str_replace(["\r","\n","\t"], ['','',' '], $bkmk_str);
+    $bkmk_str = str_replace(array("\r","\n","\t"), array('','',' '), $bkmk_str);
 
     $bkmk_str = preg_replace_callback('@<dd>(.*?)(<A|<\/|<DL|<DT|<P)@mis', function($m) {
-        return '<dd>'.str_replace(["\r", "\n"], ['', '<br>'], trim($m[1])).'</';
+        return '<dd>'.str_replace(array("\r", "\n"), array('', '<br>'), trim($m[1])).'</';
     }, $bkmk_str);
 
     $bkmk_str = preg_replace('/>(\s*?)</mis', ">\n<", $bkmk_str);

--- a/parse_netscape_bookmarks.php
+++ b/parse_netscape_bookmarks.php
@@ -86,7 +86,7 @@ function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
             }
 
             if (preg_match('/add_date="(.*?)"/i', $line, $m8)) {
-                 $items[$i]['time'] = strtotime($m8[0]) ?: time();
+                $items[$i]['time'] = parse_bookmark_date($m8[1]);
             } else {
                 $items[$i]['time'] = time();
             }
@@ -103,4 +103,29 @@ function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
     ksort($items);
 
     return $items;
+}
+
+
+/**
+ * Parses a formatted date
+ *
+ * @see http://php.net/manual/en/datetime.formats.compound.php
+ * @see http://php.net/manual/en/function.strtotime.php
+ *
+ * @param string $date formatted date
+ *
+ * @return int Unix timestamp corresponding to a successfully parsed date,
+ *             else current date and time
+ */
+function parse_bookmark_date($date)
+{
+    if (strtotime('@'.$date)) {
+        # Unix timestamp
+        return strtotime('@'.$date);
+    } else if (strtotime($date)) {
+        # attempt to parse a known compound date/time format
+        return strtotime($date);
+    }
+    # current date & time
+    return time();
 }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -21,6 +21,7 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Secret stuff', $bkm[0]['title']);
         $this->assertEquals(0, $bkm[0]['pub']);
         $this->assertEquals('private secret', $bkm[0]['tags']);
+        $this->assertEquals('971175336', $bkm[0]['time']);
         $this->assertEquals(
             'Super-secret stuff you\'re not supposed to know about',
             $bkm[0]['note']
@@ -29,6 +30,45 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Public stuff', $bkm[1]['title']);
         $this->assertEquals(1, $bkm[1]['pub']);
         $this->assertEquals('public hello world', $bkm[1]['tags']);
+        $this->assertEquals('1456433748', $bkm[1]['time']);
         $this->assertEquals('', $bkm[1]['note']);
+    }
+
+    /**
+     * Parse log dates
+     */
+    public function test_parse_log_dates()
+    {
+        $this->assertEquals(
+            '971211336',
+            parse_bookmark_date('10/Oct/2000:13:55:36 -0700')
+        );
+        $this->assertEquals(
+            '971186136',
+            parse_bookmark_date('10/Oct/2000:13:55:36 +0000')
+        );
+        $this->assertEquals(
+            '971175336',
+            parse_bookmark_date('10/Oct/2000:13:55:36 +0300')
+        );
+    }
+
+    /**
+     * Parse Unix timestamps
+     */
+    public function test_parse_unix_dates()
+    {
+        $this->assertEquals(
+            '1456433748',
+            parse_bookmark_date('1456433748')
+        );
+        $this->assertEquals(
+            '971175336',
+            parse_bookmark_date('971175336')
+        );
+        $this->assertEquals(
+            '-371211336',
+            parse_bookmark_date('-371211336')
+        );
     }
 }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Ensure basic Netscape bookmarks are properly parsed
+ *
+ * @see https://msdn.microsoft.com/en-us/library/aa753582%28v=vs.85%29.aspx
+ * @see http://www.w3schools.com/tags/tag_dl.asp
+ */
+class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Parse a basic Netscape file
+     */
+    public function test_parse_basic()
+    {
+        $bkm = parse_netscape_bookmarks(
+            file_get_contents('tests/input/netscape_basic.htm')
+        );
+        $this->assertEquals(2, sizeof($bkm));
+
+        $this->assertEquals('Secret stuff', $bkm[0]['title']);
+        $this->assertEquals(0, $bkm[0]['pub']);
+        $this->assertEquals('private secret', $bkm[0]['tags']);
+        $this->assertEquals(
+            'Super-secret stuff you\'re not supposed to know about',
+            $bkm[0]['note']
+        );
+
+        $this->assertEquals('Public stuff', $bkm[1]['title']);
+        $this->assertEquals(1, $bkm[1]['pub']);
+        $this->assertEquals('public hello world', $bkm[1]['tags']);
+        $this->assertEquals('', $bkm[1]['note']);
+    }
+}

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -71,4 +71,91 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
             parse_bookmark_date('-371211336')
         );
     }
+
+    /**
+     * Use a default tag if none is found
+     */
+    public function test_add_default_tag()
+    {
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://no.tag">NoTag</A>'
+        );
+        $this->assertEquals(
+            'imported-'.date('Ymd'),
+            $bkm[0]['tags']
+        );
+    }
+
+    /**
+     * Use a user-defined default tag if none is found
+     */
+    public function test_add_user_default_tag()
+    {
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://no.tag">NoTag</A>',
+            'im port ed'
+        );
+        $this->assertEquals(
+            'im port ed',
+            $bkm[0]['tags']
+        );
+    }
+
+    /**
+     * Keep empty tags
+     */
+    public function test_parse_empty_tags()
+    {
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://empty.tag" TAGS="">EmptyTag</A>'
+        );
+        $this->assertEquals(
+            '',
+            $bkm[0]['tags']
+        );
+    }
+
+    /**
+     * Parse space-separated tags
+     */
+    public function test_parse_space_tags()
+    {
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://space.tag" TAGS="t1 t2">SpaceTag</A>'
+        );
+        $this->assertEquals(
+            't1 t2',
+            $bkm[0]['tags']
+        );
+
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://space.tag" TAGS="t_1 .t_2">SpaceTag</A>'
+        );
+        $this->assertEquals(
+            't_1 .t_2',
+            $bkm[0]['tags']
+        );
+    }
+
+    /**
+     * Parse comma-separated tags
+     */
+    public function test_parse_comma_tags()
+    {
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://comma.tag" TAGS="t1,t2,t3">CommaTag</A>'
+        );
+        $this->assertEquals(
+            't1 t2 t3',
+            $bkm[0]['tags']
+        );
+
+        $bkm = parse_netscape_bookmarks(
+            '<A HREF="http://comma.tag" TAGS="t1,.t2,.t_3">CommaTag</A>'
+        );
+        $this->assertEquals(
+            't1 .t2 .t_3',
+            $bkm[0]['tags']
+        );
+    }
 }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -35,6 +35,27 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Parse a Netscape file containing multiline descriptions
+     */
+    public function test_parse_multiline_descriptions()
+    {
+        $bkm = parse_netscape_bookmarks(
+            file_get_contents('tests/input/netscape_multiline.htm')
+        );
+        $this->assertEquals(2, sizeof($bkm));
+        $this->assertEquals(
+            'List:'.PHP_EOL.'- item1'.PHP_EOL.'- item2'.PHP_EOL.'- item3',
+            $bkm[0]['note']
+        );
+        $this->assertEquals(
+            'Nested lists:'
+           .PHP_EOL.'- list1'.PHP_EOL.'  - item1.1'.PHP_EOL.'  - item1.2'.PHP_EOL.'  - item1.3'
+           .PHP_EOL.'- list2'.PHP_EOL.'  - item2.1',
+            $bkm[1]['note']
+        );
+    }
+
+    /**
      * Parse log dates
      */
     public function test_parse_log_dates()

--- a/tests/input/netscape_basic.htm
+++ b/tests/input/netscape_basic.htm
@@ -1,0 +1,11 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="https://private.tld" ADD_DATE="" PRIVATE="1" TAGS="private secret">Secret stuff</A>
+<DD>Super-secret stuff you're not supposed to know about
+<DT><A HREF="http://public.tld" ADD_DATE="" PRIVATE="0" TAGS="public hello world">Public stuff</A>
+</DL><p>

--- a/tests/input/netscape_basic.htm
+++ b/tests/input/netscape_basic.htm
@@ -5,7 +5,7 @@ Do Not Edit! -->
 <TITLE>Bookmarks</TITLE>
 <H1>Bookmarks</H1>
 <DL><p>
-<DT><A HREF="https://private.tld" ADD_DATE="" PRIVATE="1" TAGS="private secret">Secret stuff</A>
+<DT><A HREF="https://private.tld" ADD_DATE="10/Oct/2000:13:55:36 +0300" PRIVATE="1" TAGS="private secret">Secret stuff</A>
 <DD>Super-secret stuff you're not supposed to know about
-<DT><A HREF="http://public.tld" ADD_DATE="" PRIVATE="0" TAGS="public hello world">Public stuff</A>
+<DT><A HREF="http://public.tld" ADD_DATE="1456433748" PRIVATE="0" TAGS="public hello world">Public stuff</A>
 </DL><p>

--- a/tests/input/netscape_multiline.htm
+++ b/tests/input/netscape_multiline.htm
@@ -1,0 +1,21 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="http://multi.li.ne/1" ADD_DATE="1456433741" PRIVATE="0" TAGS="multi">Multiline desc</A>
+<DD>List:
+- item1
+- item2
+- item3
+<DT><A HREF="http://multi.li.ne/2" ADD_DATE="1456433742" PRIVATE="0" TAGS="multi">Multiline desc</A>
+<DD>Nested lists:
+- list1
+  - item1.1
+  - item1.2
+  - item1.3
+- list2
+  - item2.1
+</DL><p>


### PR DESCRIPTION
Hi @kafene , and thanks for sharing this useful parsing script ;-)

We would like to integrate it in the [Shaarli](https://github.com/shaarli/Shaarli) bookmarking application as part of our refactoring efforts; as a preliminary work, I've started to bring some improvements and fixes, namely:
- [PHPUnit](https://phpunit.de/) test framework to write unitary tests
- [Travis CI](https://travis-ci.org/) automated builds
- PHP 5.3 compatibility (use `array()` instead of the short `[]` syntax)
- parsing fixes/improvements:
  - better date format support
  - multi-line descriptions

The next planned tasks are:
- ensuring common bookmark exports are properly supported: Firefox, Diigo, Delicious, etc.
- add test coverage for other attributes

As development has been kept atomic, commit messages should be self-explanatory regarding what's been added :)

Cheers,

VirtualTam
